### PR TITLE
fix pr template.md file

### DIFF
--- a/.github/workflows/PULL_REQUEST_TEMPLATE.md
+++ b/.github/workflows/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,3 @@
-
 <!--
 Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
 -->

--- a/posts/welcome/index.qmd
+++ b/posts/welcome/index.qmd
@@ -6,7 +6,6 @@ categories: [news]
 google-scholar: true
 citation:
   type: post-weblog
-citation:
   url: https://oscsa-en-blog.netlify.app/posts/welcome/
 ---
 


### PR DESCRIPTION
Fixes: https://github.com/Open-Science-Community-Saudi-Arabia/OSCSA-en-blog/issues/43

PR Description:
- Fix the existing PR template file by removing repeated citation metadata on the index.qmd file, the repeated citation metadata throws an error when running the "quarto preview"
